### PR TITLE
fix: wrong dim column choosed

### DIFF
--- a/testGtrack.py
+++ b/testGtrack.py
@@ -133,10 +133,10 @@ def gtrack_cppyy_step(hTrackModule,pointCloudList,use3D=True):
     if(mNum > maxNum):
         raise ValueError(f"point num: {mNum}, exceed maximum supported num: {maxNum}")
     
-    dim = 4 if use3D else 3
+    dim = 3 if use3D else 2
     pointCloud = gbl.pointCloud # Pointer to an array of input measurments. Each measurement has range/angle/radial velocity information
     for idx, pointInfo in enumerate(pointCloudList):
-        pointCloud[idx].array = np.array(pointInfo[0],dtype=np.float32)[:dim]
+        pointCloud[idx].array = np.array(pointInfo[0][:dim]+pointInfo[0][-1:],dtype=np.float32)
         pointCloud[idx].snr = pointInfo[1]
     
     var = cppyy.nullptr # Pointer to an array of input measurment variances. Shall be set to NULL if variances are unknown


### PR DESCRIPTION
我注意到 [这段代码里的[:dim]](https://github.com/gaoweifan/pyRadar/blob/f22aeaf44b368cb8771aafe019185bb9553e58ee/testGtrack.py#L139) 会导致导入3D数据时选择数据的前三列，使得2D点云的输入数据变成 r, θ, φ 而不是 r, θ, v，这可能会引起一些误解，修正已经在此pr做出